### PR TITLE
Fix problem where god-mode was not on in new files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a global minor mode for entering Emacs commands without
 modifier keys. It's similar to Vim's separation of commands and
-insertion mode. Activate by running `M-x god-mode`.
+insertion mode. Activate for all buffers by running `M-x god-mode`.
 
 Toggle between God mode and non-God mode using `ESC`:
 
@@ -48,6 +48,21 @@ This library defines the following mapping:
 
 * There is a key (default `i` - think *insert*) to disable God mode,
   similar to Vim's i.
+
+## Global god-mode and excempt major modes
+
+If you do `M-x god-mode`, then all buffers will be started in God
+mode. If you don't like that behavior, just use the `god-local-mode`
+toggler with a keybinding.
+
+Sometimes `god-mode` is enabled in buffers where it makes no sense. In
+that case you can add the major mode to `god-excempt-major-modes`:
+
+    (add-to-list 'god-excempt-major-modes 'dired-mode)
+
+Since `dired-mode` is already in the list, that's a noop, but you get
+the idea. Consider opening an issue or pull request if you find a
+major mode that should be on the official list.
 
 ## Not implemented yet
 

--- a/god-mode.el
+++ b/god-mode.el
@@ -6,7 +6,7 @@
 
 ;; Author: Chris Done <chrisdone@gmail.com>
 ;; URL: https://github.com/chrisdone/god-mode
-;; Version: 2.4.0
+;; Version: 2.5.0
 
 ;; This file is not part of GNU Emacs.
 
@@ -71,6 +71,13 @@
   "The key used for literal interpretation."
   :group 'god
   :type 'string)
+
+(defcustom god-excempt-major-modes
+  '(dired-mode
+    magit-log-edit-mode)
+  "List of major modes that should not start in god-local-mode."
+  :group 'god
+  :type '(function))
 
 (defvar god-global-mode nil
   "Activate God mode on all buffers?")
@@ -181,23 +188,14 @@ call it."
         (:else
          (error "God: Unknown key binding for `%s`" formatted))))
 
-(defadvice display-buffer (before god activate)
-  (god-mode-activate))
+(add-hook 'after-change-major-mode-hook 'god-mode-maybe-activate)
 
-(defadvice switch-to-buffer (before god activate)
-  (god-mode-activate))
-
-(defun god-mode-activate ()
-  "Activate God mode locally on individual buffers when they are
-somehow activated."
-  (cond (god-global-mode
-         (unless god-local-mode
-           (god-local-mode 1)))
-        (god-local-mode
-         (god-local-mode -1))))
-
-(ad-activate 'display-buffer)
-(ad-activate 'switch-to-buffer)
+(defun god-mode-maybe-activate ()
+  "Activate God mode locally on individual buffers when appropriate."
+  (when (and god-global-mode
+             (not (minibufferp))
+             (not (memq major-mode god-excempt-major-modes)))
+    (god-local-mode 1)))
 
 (provide 'god-mode)
 


### PR DESCRIPTION
I've changed the global god-mode initialization so that it's not so flaky when opening new files.

The problem now is that it's enabled everywhere-everywhere. I've weeded out a few cases where it shouldn't be enabled (mainly in the minibuffer), and added some machinery to easily expand that list.
