### PR TITLE
Fix error with non-ascii self insert commands

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -126,7 +126,7 @@
 (defun god-mode-self-insert ()
   "Handle self-insert keys."
   (interactive)
-  (let ((key (this-command-keys)))
+  (let ((key (char-to-string (aref (this-command-keys-vector) 0))))
     (god-mode-interpret-key key)))
 
 (defun god-mode-repeat ()


### PR DESCRIPTION
- this-command-keys return a vector for chars like æ, ø and å.
- so always get the vector and do char-to-string on it ourselves
