### PR TITLE
Pretend to be the actual command

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -182,6 +182,8 @@
   "Execute extended keymaps such as C-c, or if it is a command,
 call it."
   (cond ((commandp binding)
+         (setq this-original-command binding)
+         (setq this-command binding)
          (setq god-mode-last-command binding)
          (setq god-mode-last-prefix-arg current-prefix-arg)
          (call-interactively binding))


### PR DESCRIPTION
Pretend to be the actual command with global vars `this-command` and `this-original-command` instead of always posing as god-mode-self-insert.
- this helps other packages (eg. multiple cursors) to know what is going on
