### PR TITLE
Run hooks when god-local-mode is enabled/disabled

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -93,7 +93,7 @@
 ;;;###autoload
 (defun god-mode ()
   (interactive)
-  "Activate/deactivate God mode."
+   "Toggle global God mode."
   (setq god-global-mode (not god-global-mode))
   (if god-global-mode
       (god-local-mode 1)
@@ -112,7 +112,10 @@
 ;;;###autoload
 (define-minor-mode god-local-mode
   "Minor mode for running commands."
-  :lighter " God")
+  nil " God" god-local-mode-map
+  (if god-local-mode
+      (run-hooks 'god-mode-enabled-hook)
+    (run-hooks 'god-mode-disabled-hook)))
 
 (defun god-mode-meta ()
   "The command for M-."


### PR DESCRIPTION
I use this to change the cursor. Might be interesting for core?

```
(defun my-update-cursor ()
  (setq cursor-type (if (or god-local-mode buffer-read-only)
                        'box
                      'bar)))

(add-hook 'god-mode-enabled-hook 'my-update-cursor)
(add-hook 'god-mode-disabled-hook 'my-update-cursor)
```
