### PR TITLE
Add git-commit-mode to exempt modes

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -41,6 +41,7 @@
 
 (defcustom god-exempt-major-modes
   '(dired-mode
+    git-commit-mode
     grep-mode
     magit-status-mode
     magit-log-edit-mode


### PR DESCRIPTION
With current Magit, commit buffers are opened via Emacsclient into [git-commit-mode](https://github.com/magit/git-modes) instead of `magit-log-edit-mode`. Working on the assumption that `magit-log-edit-mode` is already on this list, I've updated it to work the same for current Magit.
