### PR TITLE
Disable god-mode on comint-mode related buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Another option to control god-mode's global behavior is to provide a
 function with no arguments that must return non-nil if god-mode should
 be disabled for the current buffer. See the `god-exempt-predicates`
 variable and its default members `god-exempt-mode-p`,
-`god-view-mode-p` and `god-special-mode-p` for further details.
+`god-comint-mode-p`, `god-view-mode-p` and `god-special-mode-p` for
+further details.
 
 ## Not implemented yet
 

--- a/features/predicates-disable.feature
+++ b/features/predicates-disable.feature
@@ -5,6 +5,7 @@ Feature: Predicate based disable
     And I describe function "god-mode"
     And I grep current directory
     And I view the units table
+    And I start ielm
 
   Scenario: God mode is automatically enabled for fundamental-mode
     When I switch to buffer "god-mode-test"
@@ -20,4 +21,8 @@ Feature: Predicate based disable
 
   Scenario: God mode is disabled in *Units Table* (has view-mode enabled)
     When I switch to buffer "*Units Table*"
+    Then god-mode is disabled
+
+  Scenario: God mode is disabled in comint derived buffers
+    When I switch to buffer "*ielm*"
     Then god-mode is disabled

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -22,6 +22,11 @@
          (require 'calc-units)
          (math-build-units-table-buffer nil)))
 
+(Given "^I start ielm$"
+       (lambda ()
+         (require 'ielm)
+         (ielm)))
+
 (When "I switch to buffer \"\\(.+\\)\""
       (lambda (buffer)
         (switch-to-buffer buffer)))

--- a/god-mode.el
+++ b/god-mode.el
@@ -51,7 +51,10 @@
   :type '(function))
 
 (defcustom god-exempt-predicates
-  (list #'god-exempt-mode-p #'god-view-mode-p #'god-special-mode-p)
+  (list #'god-exempt-mode-p
+        #'god-comint-mode-p
+        #'god-view-mode-p
+        #'god-special-mode-p)
   "List of predicates checked before enabling god-local-mode.
 All predicates must return nil for god-local-mode to start."
   :group 'god
@@ -226,6 +229,10 @@ Members of the `god-exempt-major-modes' list are exempt."
           ((not (null parent))
            (god-mode-child-of-p parent parent-mode))
           (t nil))))
+
+(defun god-comint-mode-p ()
+  "Return non-nil if major-mode is child of comint-mode."
+  (god-mode-child-of-p major-mode 'comint-mode))
 
 (defun god-special-mode-p ()
   "Return non-nil if major-mode is child of special-mode."


### PR DESCRIPTION
Even though I'm getting quite accustomed to using god-mode, whenever I start a shell process I start typing right away while god mode is enabled and I end up doing weird stuff to it. Since comint buffers are intended for user interaction with the shell, it makes sense to me to disable god mode when they are spawned.
