### PR TITLE
Key interpreter refactor

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -156,6 +156,7 @@ enabled. See also `god-local-mode-resume'."
     (prior "<prior>")
     (next "<next>")
     (backspace "DEL")
+    (return "RET")
     (t (char-to-string key))))
 
 (defun key-string-after-consuming-key (key key-string-so-far)


### PR DESCRIPTION
Hey @chrisdone, I would be love to get your feedback on this refactor. I think this simplifies a few things.

It's a bit more modular in a few places, in preparation for a change I'm working on that allows you to use `describe-key` with god-mode keybindings (I find it quite annoying to have hold down ctrl to find out what a key is bound to while I'm in god-mode).

``` lisp
(defun god-mode-describe-key ()
  "Like `describe-key', but uses god-mode keybindings."
  (interactive)
  (describe-function (god-mode-lookup-key-sequence)))
```

Also, these keybindings fold into the core god-mode key interpreter:

``` lisp
(define-key map (kbd "g") 'god-mode-meta)
(define-key map (kbd "G") 'god-mode-control-meta)
```

It might be better to move `god-literal-sequence` back into an argument to avoid global state. Let me know your thoughts on that. I'm open to any suggestions to help improve this!

Cheers,

Dillon
