### PR TITLE
Fixes #45, Reference to free variable error

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -96,7 +96,6 @@ enabled. See also `god-local-mode-resume'."
     (setq god-local-mode-paused nil)
     (god-local-mode 1)))
 
-
 (defvar god-global-mode nil
   "Activate God mode on all buffers?")
 


### PR DESCRIPTION
Closes #45 

The error was caused by a reference to 'god-local-mode' in the definition of 'god-mode',
moving the definition of 'god-local-mode' before the definition of 'god-mode' solved the issue.
