### PR TITLE
Add support for numbered function keys F1-F35

### DIFF
--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -108,3 +108,27 @@ Feature: C- commands
     And I go to end of buffer
     And I send the key sequence "C-c S-<left>"
     Then the cursor should be at point "1"
+
+  Scenario: execute commands with numbered function keys (literal)
+    Given I bind "C-c <f12>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "c SPC <f12>"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with numbered function keys (control)
+    Given I bind "C-c C-<f12>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "c <f12>"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with numbered function keys (meta)
+    Given I bind "C-c M-<f12>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "c g <f12>"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with numbered function keys (control+shift)
+    Given I bind "C-c C-S-<f12>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "c S-<f12>"
+    Then the cursor should be at point "1"


### PR DESCRIPTION
Hi,

This PR enables God Mode to see bindings on the F1-F35 function keys, as a convenience for users who bind commands to \<C-F3\> \<M-F5\> etc. I am using this feature currently to reduce RSI.

The implementation is pretty simple:
* The F-keys and their shifted equivalents are bound to `god-mode-self-insert-map` and handled just like the other self-inserting keys.
* The sanitized key strings lookup table has been moved to a variable to avoid recomputing it for each keypress. This also makes it easier to customize should someone have the need.

One thing deliberately omitted is to update the shift-translation state as is done for alphabetic keys in `god-mode-self-insert`. The omission is called out in a code comment. There are 2 reasons for it:
* Marginal benefit is not worth the added code complexity.

  _Details: While Emacs does shift-translate the F-keys, supporting it in God Mode would add little benefit. From the Elisp manual it appears the main (only?) use of shift-translation is to activate the region automatically when certain movement commands are used with a shift modifier. Users are unlikely to bind F-keys to movement commands._
* God Mode's management of shift-translation seems possibly broken, even though some users might rely on this behavior. This is purely my opinion of course - perhaps there is a convention I've missed. That said, it seems safest to leave it alone and if someone needs shift-translation for the F keys they can implement it later.

  _Details: Setting the shift-translation status to `t` when any uppercase key is encountered is arbitrary and likely to produce unexpected behavior: it forces any shift-modified binding triggered by God Mode to activate the region, even when using that binding outside God Mode would not activate the region. For example, do `(define-key global-map (kbd "C-S-t") 'left-char)` and observe that pressing C-S-t outside God Mode simply moves point, whereas pressing S-t inside God Mode moves point and also activates the region._

Thanks,
Jacob
