### PR TITLE
New command: god-execute-with-current-bindings

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -278,9 +278,9 @@ When choosing a solution, consider the following questions:
 * Do I wish to use God mode for occasional, single commands (similar in spirit
 to `evil-execute-in-emacs-state`), or to use it in a sustained manner?
 * Do I need Evil-specific keybindings to be accessible within God mode, or will
-I use God mode to access default Emacs bindings? For example, when I press "v"
-in God mode, should it run `evil-visual-block` (Evil's default binding for C-v)
-or `scroll-up-command` (Emacs' default)?
+I use God mode to access default Emacs bindings? For example, when I press
+<kbd>v</kbd> in God mode, should it run `evil-visual-block` (Evil's default
+binding for <kbd>C-v</kbd>) or `scroll-up-command` (Emacs' default)?
 * Do I want God mode to have a dedicated state within Evil, or do I want to
 remain inside the classic Evil states while using it?
 
@@ -289,16 +289,17 @@ remain inside the classic Evil states while using it?
 For running occasional, single commands via God mode, the built-in command
 `god-execute-with-current-bindings` works well with Evil without additional
 customization. All Evil bindings remain available when using this command,
-so e.g. pressing v will run `evil-visual-block`.
+so e.g. pressing <kbd>v</kbd> will run `evil-visual-block`.
 
 For sustained usage of God mode, it gets trickier. Evil's keybindings in Motion,
 Normal, and Visual states generally override God mode. For example, if I am in
-Normal state and activate God mode, pressing v runs the Normal state binding for
-v (`evil-visual-char`) just as though God mode were not active. This behavior
-may be fine if all you want to do is run Emacs commands using God mode from
-within Insert state, since Evil doesn't bind most unmodified keys in Insert. If
-you need to access Evil bindings using God state, you'll need to apply the
-following customization for each Evil state `STATE` where you wish to do so:
+Normal state and activate God mode, pressing <kbd>v</kbd> runs the Normal state
+binding for <kbd>v</kbd> (`evil-visual-char`) just as though God mode were not
+active. This behavior may be fine if all you want to do is run Emacs commands
+using God mode from within Insert state, since Evil doesn't bind most unmodified
+keys in Insert. If you need to access Evil bindings using God state, you'll need
+to apply the following customization for each Evil state `STATE` where you wish
+to do so:
 
 ```emacs-lisp
 (evil-make-intercept-map
@@ -315,9 +316,9 @@ For example:
 As a reminder these customizations are *not* necessary if you only use God mode
 via `god-execute-with-current-bindings`.
 
-### evil-god-state
+### `evil-god-state`
 
-Another option is to use the package [evil-god-state][evil-god-state].
+Another option is to use the package [`evil-god-state`][evil-god-state].
 This package provides a dedicated Evil state for using God mode.
 
 For running occasional, single commands via God mode, the package provides
@@ -329,17 +330,17 @@ An advantage of using a dedicated Evil state is that it provides built-in
 integration with the Evil mode line indicator. A disadvantage is that Evil's
 state-specific keybindings from other states are not available in God state.
 This is true whether using `evil-god-state` directly, or via
-`evil-execute-in-god-state`.  Thus, evil-god-state is most useful for accessing
-Emacs default bindings through God mode.
+`evil-execute-in-god-state`.  Thus, `evil-god-state` is most useful for
+accessing Emacs default bindings through God mode.
 
 ### Summary
 
-To minimize the amount of customizations you must apply:
+To minimize the amount of customization you must apply:
 * If you do not want a dedicated Evil state for God mode, and/or want to access
 Evil state-specific bindings via God mode, use built-in God mode features as
 described.
 * If you want a dedicated Evil state for God mode, and/or want to access only
-Emacs default bindings via God mode, use evil-god-state.
+Emacs default bindings via God mode, use `evil-god-state`.
 
 [useful-key-bindings]: #useful-key-bindings
 [key-mapping]: #key-mapping

--- a/.github/README.md
+++ b/.github/README.md
@@ -266,6 +266,81 @@ disabled in the current buffer. See the `god-exempt-predicates` variable and its
 default members `god-exempt-mode-p`, `god-comint-mode-p`, `god-view-mode-p` and
 `god-special-mode-p` for further details.
 
+## Use with Evil
+
+[Evil][evil] is a popular Emacs package that provides modal editing in the style
+of Vi. While it doesn't always work well with God mode by default, there are
+some simple customizations that enable them to be used together smoothly.
+
+### Considerations
+
+When choosing a solution, consider the following questions:
+* Do I wish to use God mode for occasional, single commands (similar in spirit
+to `evil-execute-in-emacs-state`), or to use it in a sustained manner?
+* Do I need Evil-specific keybindings to be accessible within God mode, or will
+I use God mode to access default Emacs bindings? For example, when I press "v"
+in God mode, should it run `evil-visual-block` (Evil's default binding for C-v)
+or `scroll-up-command` (Emacs' default)?
+* Do I want God mode to have a dedicated state within Evil, or do I want to
+remain inside the classic Evil states while using it?
+
+### Using built-in functionality
+
+For running occasional, single commands via God mode, the built-in command
+`god-execute-with-current-bindings` works well with Evil without additional
+customization. All Evil bindings remain available when using this command,
+so e.g. pressing v will run `evil-visual-block`.
+
+For sustained usage of God mode, it gets trickier. Evil's keybindings in Motion,
+Normal, and Visual states generally override God mode. For example, if I am in
+Normal state and activate God mode, pressing v runs the Normal state binding for
+v (`evil-visual-char`) just as though God mode were not active. This behavior
+may be fine if all you want to do is run Emacs commands using God mode from
+within Insert state, since Evil doesn't bind most unmodified keys in Insert. If
+you need to access Evil bindings using God state, you'll need to apply the
+following customization for each Evil state `STATE` where you wish to do so:
+
+```emacs-lisp
+(evil-make-intercept-map
+     (evil-get-auxiliary-keymap god-local-mode-map 'god t t) 'STATE)
+```
+
+For example:
+
+```emacs-lisp
+(evil-make-intercept-map
+     (evil-get-auxiliary-keymap god-local-mode-map 'god t t) 'normal)
+```
+
+As a reminder these customizations are *not* necessary if you only use God mode
+via `god-execute-with-current-bindings`.
+
+### evil-god-state
+
+Another option is to use the package [evil-god-state][evil-god-state].
+This package provides a dedicated Evil state for using God mode.
+
+For running occasional, single commands via God mode, the package provides
+`evil-execute-in-god-state`. This works similar to
+`god-execute-with-current-bindings`. For sustained use, just use the command
+`evil-god-state`.
+
+An advantage of using a dedicated Evil state is that it provides built-in
+integration with the Evil mode line indicator. A disadvantage is that Evil's
+state-specific keybindings from other states are not available in God state.
+This is true whether using `evil-god-state` directly, or via
+`evil-execute-in-god-state`.  Thus, evil-god-state is most useful for accessing
+Emacs default bindings through God mode.
+
+### Summary
+
+To minimize the amount of customizations you must apply:
+* If you do not want a dedicated Evil state for God mode, and/or want to access
+Evil state-specific bindings via God mode, use built-in God mode features as
+described.
+* If you want a dedicated Evil state for God mode, and/or want to access only
+Emacs default bindings via God mode, use evil-god-state.
+
 [useful-key-bindings]: #useful-key-bindings
 [key-mapping]: #key-mapping
 [switch-caps-lock-and-esc]: https://askubuntu.com/questions/363346/how-to-permanently-switch-caps-lock-and-esc
@@ -275,3 +350,5 @@ default members `god-exempt-mode-p`, `god-comint-mode-p`, `god-view-mode-p` and
 [melpa-stable-badge]: https://stable.melpa.org/packages/god-mode-badge.svg
 [gh-actions-link]: https://github.com/emacsorphanage/god-mode/actions
 [gh-actions-badge]: https://github.com/emacsorphanage/god-mode/workflows/CI/badge.svg
+[evil]: https://github.com/emacs-evil/evil
+[evil-god-state]: https://github.com/gridaphobe/evil-god-state

--- a/features/execute-with-current-bindings.feature
+++ b/features/execute-with-current-bindings.feature
@@ -1,0 +1,24 @@
+Feature: Execute with current bindings
+  Background:
+    Given I am in buffer "god-mode-test"
+    And I bind "C-e" to "god-execute-with-current-bindings"
+    And the buffer is empty
+    And I insert "abcdefghijkl"
+    And I go to beginning of buffer
+
+  Scenario: no effect when already in God mode
+    Given I have god-mode on
+    When I send the key sequence "C-e q Z"
+    Then the buffer's contents should be "Zabcdefghijkl"
+    And god-mode is enabled
+    
+  Scenario: runs one command in God mode
+    Given I am in insertion mode
+    When I send the key sequence "C-e q Z"
+    Then the buffer's contents should be "Zabcdefghijkl"
+    And god-mode is disabled
+
+  Scenario: handles prefix arguments
+    Given I am in insertion mode
+    When I send the key sequence "C-u 1 C-e 0 f"
+    Then the cursor should be at point "11"

--- a/god-mode.el
+++ b/god-mode.el
@@ -351,6 +351,7 @@ Members of the `god-exempt-major-modes' list are exempt."
            (throw 'disable t))
          (setq preds (cdr preds)))))))
 
+;;;###autoload
 (defun god-execute-with-current-bindings (&optional called-interactively)
     "Execute a single command from God mode, preserving current keybindings.
 

--- a/god-mode.el
+++ b/god-mode.el
@@ -351,6 +351,76 @@ Members of the `god-exempt-major-modes' list are exempt."
            (throw 'disable t))
          (setq preds (cdr preds)))))))
 
+(defun god-execute-with-current-bindings (&optional called-interactively)
+    "Execute a single command from God mode, preserving current keybindings.
+
+This command activates God mode temporarily, and deactivates God
+mode as soon as the next command is run.  Prefix arguments do not
+count as commands for this purpose, and do not cause God mode to
+exit.  Moreover, any prefix argument that exists at the time of
+this command's invocation is passed along to the next command.
+
+Unlike normal use of God mode, this command makes available all
+keybindings that were active at the time of its invocation,
+including keybindings that are normally invisible to God mode,
+such as those in `emulation-mode-map-alists' or text overlay
+properties.  This makes it suitable for use with packages like
+Evil that utilize such higher-priority keymaps.  (See Info
+node `(elisp)Active Keymaps' for technical details on keymap
+precedence.  For an alternative to this command, check out the
+evil-god-state package, available on MELPA.)
+
+This command has no effect when called from within God mode.
+
+For interactive use only.  CALLED-INTERACTIVELY is a dummy
+parameter to help enforce this restriction."
+    (interactive "d")
+    (if called-interactively
+        (unless god-local-mode
+          (message "Switched to God mode for the next command ...")
+          (letrec ((caller this-command)
+                   (buffer (current-buffer))
+                   (temp-map (make-composed-keymap
+                              (cons god-local-mode-map (current-active-maps))))
+                   (cleanup
+                    (lambda ()
+                      ;; Perform cleanup in original buffer even if the command
+                      ;; switched buffers
+                      (with-current-buffer buffer
+                        (unwind-protect (god-local-mode 0)
+                          (remove-hook 'post-command-hook post-hook)))))
+                   (post-hook
+                    (lambda ()
+                      (unless (and
+                               (eq this-command caller)
+                               ;; If we've entered the minibuffer, this implies
+                               ;; a non-prefix command was run, even if
+                               ;; `this-command' has not changed.  For example,
+                               ;; `execute-extended-command' behaves this way.
+                               (not (window-minibuffer-p)))
+                        (funcall kill-temp-map))))
+                   (kill-temp-map
+                    (set-transient-map temp-map 'god-prefix-command-p cleanup)))
+            (add-hook 'post-command-hook post-hook)
+            ;; Pass the current prefix argument along to the next command
+            (setq prefix-arg current-prefix-arg)
+            ;; Technically we don't need to activate God mode since the
+            ;; transient keymap is already in place, but it's useful to provide
+            ;; a mode line lighter and run any hook functions the user has set
+            ;; up.  This could be made configurable in the future.
+            (god-local-mode 1)))
+      (error "This function should only be called interactively")))
+
+(defun god-prefix-command-p ()
+  "Return non-nil if the current command is a \"prefix\" command.
+This includes prefix arguments and any other command that should
+be ignored by `god-execute-with-current-bindings'."
+  (memq this-command '(god-mode-self-insert
+                       digit-argument
+                       negative-argument
+                       universal-argument
+                       universal-argument-more)))
+
 (provide 'god-mode)
 
 ;;; god-mode.el ends here

--- a/god-mode.el
+++ b/god-mode.el
@@ -389,6 +389,8 @@ parameter to help enforce this restriction."
                       (with-current-buffer buffer
                         (unwind-protect (god-local-mode 0)
                           (remove-hook 'post-command-hook post-hook)))))
+                   (kill-temp-map
+                    (set-transient-map temp-map 'god-prefix-command-p cleanup))
                    (post-hook
                     (lambda ()
                       (unless (and
@@ -398,9 +400,7 @@ parameter to help enforce this restriction."
                                ;; `this-command' has not changed.  For example,
                                ;; `execute-extended-command' behaves this way.
                                (not (window-minibuffer-p)))
-                        (funcall kill-temp-map))))
-                   (kill-temp-map
-                    (set-transient-map temp-map 'god-prefix-command-p cleanup)))
+                        (funcall kill-temp-map)))))
             (add-hook 'post-command-hook post-hook)
             ;; Pass the current prefix argument along to the next command
             (setq prefix-arg current-prefix-arg)

--- a/god-mode.el
+++ b/god-mode.el
@@ -380,8 +380,6 @@ parameter to help enforce this restriction."
           (message "Switched to God mode for the next command ...")
           (letrec ((caller this-command)
                    (buffer (current-buffer))
-                   (temp-map (make-composed-keymap
-                              (cons god-local-mode-map (current-active-maps))))
                    (cleanup
                     (lambda ()
                       ;; Perform cleanup in original buffer even if the command
@@ -389,8 +387,9 @@ parameter to help enforce this restriction."
                       (with-current-buffer buffer
                         (unwind-protect (god-local-mode 0)
                           (remove-hook 'post-command-hook post-hook)))))
-                   (kill-temp-map
-                    (set-transient-map temp-map 'god-prefix-command-p cleanup))
+                   (kill-transient-map
+                    (set-transient-map
+                     god-local-mode-map 'god-prefix-command-p cleanup))
                    (post-hook
                     (lambda ()
                       (unless (and
@@ -400,7 +399,7 @@ parameter to help enforce this restriction."
                                ;; `this-command' has not changed.  For example,
                                ;; `execute-extended-command' behaves this way.
                                (not (window-minibuffer-p)))
-                        (funcall kill-temp-map)))))
+                        (funcall kill-transient-map)))))
             (add-hook 'post-command-hook post-hook)
             ;; Pass the current prefix argument along to the next command
             (setq prefix-arg current-prefix-arg)


### PR DESCRIPTION
Hi,

This PR adds a new command `god-execute-with-current-bindings` that switches to God mode for the next command only. The primary aim is to provide an option for users of [Evil](https://github.com/emacs-evil/evil) who wish to occasionally switch to God mode for single commands. Users of other modal editing packages, and of God mode generally, may also find it useful.

Relatedly, I have added some documentation to the readme to assist users in integrating God mode with Evil.

There is an existing package, [evil-god-state](https://github.com/gridaphobe/evil-god-state), that provides similar functionality to the new command (for Evil only). I summarize in a section below why I feel it is necessary to provide an alternative to this package.

An important technical detail of `god-execute-with-current-bindings` is that it "freezes" all active keybindings at the time of its invocation, and makes them available to God mode's lookup logic via a [transient keymap](https://www.gnu.org/software/emacs/manual/html_node/elisp/Controlling-Active-Maps.html). This is necessary to override Evil's keymaps, which live in `emulation-mode-map-alists` and thus take priority over God Mode in normal usage. An alternative approach would have been to promote `god-local-mode-map` to "intercept map" status within Evil. However, this would make the solution specific to Evil, and I'd like it to be useful with other packages that employ emulation maps, such as Company.

I have included more commentary on the rationale and technical choices below. Many thanks!

## Why not evil-god-state?

Because evil-god-state creates a dedicated Evil state for God mode, it suffers from some shortcomings:

  * _Evil bindings are not available within God state._ E.g., after switching from Normal to God state, any Normal bindings I might wish to use are lost. In the past I have fixed this by packaging up `(current-active-maps)` into a temporary keymap and setting that as the parent keymap of `god-local-mode-map` just before entering God state. This technique also requires giving `god-local-mode-map` status as an "intercept map" within Evil, so the `god-mode-self-insert` bindings aren't hidden by Evil. There are surely other ways to achieve the same effect but I suspect they're equally hacky.
  * _Evil's state management is clunky._ Evil has special rules about entering and exiting certain states, and makes some assumptions that break God state. Getting the "delicate dance" of states and post-command hooks to work correctly is difficult. This observation is from personal experience customizing evil-god-state but is also attested by bugs like [this](https://github.com/gridaphobe/evil-god-state/issues/4) and [this](https://github.com/gridaphobe/evil-god-state/issues/10). While these bugs are surely fixable, I believe they stem from a more important, "philosophical" issue, namely...
  * _God mode is an input method, not an editing state._ Not everyone will share this view, but to me it makes more sense to think of God mode as just another alternate way of constructing key sequences, similar to choosing Left Control versus Right Control, or Caps Lock versus Shift. It shouldn't interact with state-management logic, except perhaps to deactivate itself in certain states like Insert.

I have found these issues sufficiently frustrating for my own purposes that I was motivated to create an alternative.

## Future direction

A natural question is, why not reimplement God mode's *ordinary* behavior to use a transient keymap by default, i.e., not just during `god-execute-with-current-bindings`? That would have some advantages, for example, built-in compatibility with packages like Evil and Company even when using God mode in the "ordinary" way. It would certainly be desirable from the standpoint of consistency. Unfortunately, I don't think this solution is a good idea. One problem is that, because commands can activate or deactivate keymaps, then probably in a post-command hook we'd need to deactivate the transient map, grab the new set of keymaps from `current-active-maps`, then rebuild and reapply the transient map to reflect the change. That seems possibly expensive for a post-command hook, and/or too much logic to maintain.

On the other hand, God mode could be retooled to use an emulation map, similar to how Evil works. That seems like a pretty appealing solution: it would provide the same value as using a transient map, and because emulation maps can be used on top of other keymaps, we'd avoid the necessity of rebuilding a special temporary keymap after each command. The main challenge for Evil/Company/etc. compatibility would be making sure that the God emulation map always gets top priority within `emulation-mode-map-alists`, but that doesn't seem too hard to do; at worst, users would have to be advised to load God mode after any other packages that make use of that variable.

I'd be interested in trying to patch God mode to use emulation maps in the future, and curious what the maintainers think about this idea.