### PR TITLE
Fix god-mode-upper-p's use of god-mode-alist

### DIFF
--- a/features/m-c-commands.feature
+++ b/features/m-c-commands.feature
@@ -1,0 +1,15 @@
+Feature: M-C- commands
+  Background:
+    Given I am in buffer "god-mode-test"
+    And the buffer is empty
+    And I insert "Here we go"
+    Then I have god-mode on
+
+  Scenario: mark is preserved
+    Given I go to beginning of buffer
+    And I bind "C-SPC" to "set-mark-command"
+    When I send the key sequence "SPC gfGf"
+    Then region's contents should be "Here we"
+
+
+

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -105,3 +105,11 @@ Examples:
         (let ((actual (buffer-string))
               (message "Expected buffer's contents to contain '%s', but was '%s'"))
           (cl-assert (s-contains? expected actual) nil message expected actual))))
+
+(Then "^region's contents should be\\(?: \"\\(.+\\)\"\\|:\\)$"
+      "Asserts that the current region inclues some text."
+      (lambda (expected)
+        (let ((actual (buffer-substring-no-properties
+                       (region-beginning) (region-end)))
+              (message "Expected region's contents to be '%s', but was '%s'"))
+          (cl-assert (s-equals? expected actual) nil message expected actual))))

--- a/god-mode.el
+++ b/god-mode.el
@@ -206,7 +206,7 @@ If it was not active when `god-local-mode-pause' was called, nothing happens."
 (defun god-mode-upper-p (key)
   "Check if KEY is an upper case character not present in `god-mode-alist'."
   (and (characterp key)
-       (not (member key (mapcar #'car god-mode-alist)))
+       (not (member (char-to-string key) (mapcar #'car god-mode-alist)))
        (>= key ?A)
        (<= key ?Z)))
 


### PR DESCRIPTION
The relatively recent change to remove hard-coding the `?G` character broke handling of that character. It impacted me because if I set mark, then moved point forward by a word, and then moved point forward by a sexp using `G f`, mark would be reset to the location of point when I issued the `G f` command.

For example, say you have the string "Here we go" in a buffer. Put point before the word "Here", then, in `god-mode`, hit space to activate mark, then hit "g f" to move point forward by a word. The region will cover the word "Here". If you then hit "G f", the region will move forward but no longer include include the word "Here".

Looking at the code, there is a problem because the keys of `god-mode-alist` are strings while `key` in `god-mode-upper-p` is a character. We could either make the change I have made here, or make the keys of `god-mode-alist` characters.
