### PR TITLE
Fix error if god-execute-with-current-bindings deletes buffer

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -407,9 +407,11 @@ parameter to help enforce this restriction."
                     (lambda ()
                       ;; Perform cleanup in original buffer even if the command
                       ;; switched buffers
-                      (with-current-buffer buffer
-                        (unwind-protect (god-local-mode 0)
-                          (remove-hook 'post-command-hook post-hook)))))
+                      (if (buffer-live-p buffer)
+                        (with-current-buffer buffer
+                          (unwind-protect (god-local-mode 0)
+                            (remove-hook 'post-command-hook post-hook)))
+                        (remove-hook 'post-command-hook post-hook))))
                    (kill-transient-map
                     (set-transient-map
                      god-local-mode-map 'god-prefix-command-p cleanup))


### PR DESCRIPTION
Currently if a command executed via `god-execute-with-current-bindings` results in the deletion of the current buffer, an error message is spat out in the minibuffer. This commit updates the cleanup process of `god-execute-with-current-bindings` to check if the buffer exists and is alive before disabling god-local-mode.

Fixes https://github.com/emacsorphanage/god-mode/issues/117