### PR TITLE
fixed (?) the Ecukes link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please write a failing test before submitting pull requests. All new features should be accompanied by new tests.
 
-Tests are written in [Ecukes](http://ecukes.info), an integration testing framework for Emacs.
+Tests are written in [Ecukes](https://github.com/ecukes/ecukes), an integration testing framework for Emacs.
 
 ## Setup
 


### PR DESCRIPTION
The earlier version of CONTRIBUTING.md mentions Ecukes and links to http://ecukes.info.
That website appears to be a news site that has nothing to do with Emacs. I assume the intended link is: https://github.com/ecukes/ecukes, though I am not at all familiar with Ecukes, so I am not sure