### PR TITLE
Flycheck patches

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please write a failing test before submitting pull requests. All new features should be accompanied by new tests.
 
-Tests are written in [Ecukes](http://ecukes.info), an integration testing framework for Emacs.
+Tests are written in [Ecukes](https://github.com/ecukes/ecukes), an integration testing framework for Emacs.
 
 ## Setup
 

--- a/god-mode.el
+++ b/god-mode.el
@@ -130,9 +130,12 @@ For example, calling with arguments 5 and t yields the symbol `S-f5'."
     map))
 
 ;;;###autoload
+;; Use keywords rather than deprecated positional arguments to `define-minor-mode'
 (define-minor-mode god-local-mode
   "Minor mode for running commands."
-  nil " God" god-local-mode-map
+  :init-value nil
+  :lighter " God"
+  :keymap god-local-mode-map
   (if god-local-mode
       (run-hooks 'god-mode-enabled-hook)
     (run-hooks 'god-mode-disabled-hook)))
@@ -265,7 +268,8 @@ KEY-STRING-SO-FAR should be nil for the first call in the sequence."
   (or (cdr (assq key god-mode-sanitized-key-alist))
       (char-to-string key)))
 
-(defun god-mode-help-char-dispatch (help-key key-string-so-far)
+;; FIXME: the argument help-key is not used: should it be removed?
+(defun god-mode-help-char-dispatch (_help-key key-string-so-far)
   "Invokes `prefix-help-command' by entering the key sequence KEY-STRING-SO-FAR
 followed by the `help-char' key.
 HELP-KEY contains the key that caused `god-mode-help-char-dispatch' to be called

--- a/god-mode.el
+++ b/god-mode.el
@@ -130,7 +130,6 @@ For example, calling with arguments 5 and t yields the symbol `S-f5'."
     map))
 
 ;;;###autoload
-;; Use keywords rather than deprecated positional arguments to `define-minor-mode'
 (define-minor-mode god-local-mode
   "Minor mode for running commands."
   :init-value nil
@@ -268,7 +267,6 @@ KEY-STRING-SO-FAR should be nil for the first call in the sequence."
   (or (cdr (assq key god-mode-sanitized-key-alist))
       (char-to-string key)))
 
-;; FIXME: the argument help-key is not used: should it be removed?
 (defun god-mode-help-char-dispatch (_help-key key-string-so-far)
   "Invokes `prefix-help-command' by entering the key sequence KEY-STRING-SO-FAR
 followed by the `help-char' key.


### PR DESCRIPTION
While working on the `describe-key` branch, I noticed a couple of compilation warnings in other parts of the code.
I figured it'd be better to have these "fixes" on a separate branch, to make it easier to compare.

1) the comment at line 133 is the warning I was getting: `Use keywords rather than deprecated positional arguments to `define-minor-mode'`
2) the argument `help-key` is not used. I turned off the warning by adding the underscore to the name (signaling to the compiler that it'll be ignored). But someone who's more familiar with the code can maybe decide if it should be removed completely