### PR TITLE
Unwind protect for describe key

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -525,7 +525,7 @@ into the appropriate command, and use `describe-function' to describe it"
             (progn
               (add-hook 'help-fns-describe-function-functions
                         #'god-mode--help-fn-describe-function)
-              (describe-function combmand))))
+              (describe-function command))))
     ;; unwind forms:
     (advice-remove #'god-mode-lookup-command
                    (lambda (key-string)


### PR DESCRIPTION

As mentioned by tangxinfa in a comment to the [original describe-key issue](https://github.com/emacsorphanage/god-mode/issues/144), some times the advice and hook created within the `describe-key` function are not removed (as would be expected). This can cause errors down the line.
This issue was caused by the fact that 
```
(remove-hook 'help-fns-describe-function-functions
                 #'god-mode--help-fn-describe-function)
```
was at the end of `god-mode-describe-key`, without taking into account that, in cases when `god-mode-describe-key` exits abnormally, this last part is never executed.

The solution is to use the special form `unwind-protect` which allows us to specify "unwind-forms" that are always executed, even if the body of our function exits abnormally (see the documentation for more details)