### PR TITLE
Make god-mode-all able to not only toggle god-mode by also strictly activate or deactivate it

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -170,10 +170,18 @@ If it was not active when `god-local-mode-pause' was called, nothing happens."
     (god-local-mode -1)))
 
 ;;;###autoload
-(defun god-mode-all ()
-  "Toggle `god-local-mode' in all buffers."
+(defun god-mode-all (&optional arg)
+  "Toggle `god-local-mode' in all buffers.
+
+If called from Lisp, toggle the mode if ARG is nil.  Enable the
+mode if ARG is zero or a positive number.  Disable the mode if
+ARG is a negative number."
   (interactive)
-  (let ((new-status (if (bound-and-true-p god-local-mode) -1 1)))
+  (let ((new-status
+	 (cond
+	  ((null arg) (if (bound-and-true-p god-local-mode) -1 1))
+	  ((> 0 arg) -1)
+	  (t 1))))
     (setq god-global-mode t)
     (mapc (lambda (buffer)
             (with-current-buffer buffer


### PR DESCRIPTION
I started using Emacs server and I want to make sure that god-mode is turned on globally every time a new frame is created.  However, `god-mode-all` is only capable of toggling the mode, and I needed it to enforce the mode to be turned on, otherwise the following happens:

1. Start server and god-mode is turned on from the init file
2. Create a new frame which calls `god-mode-all` from `after-make-frame-functions` and it turns off.
3. Turn it on manually and use the frame.
4. Delete the frame when I'm done with god-mode still on.
5. Create another frame which again calls `god-mode-all` from `after-make-frame-functions` and it turns off because it was left on.

If in (4) god-mode is off, then it will be turned on when I create a new frame, as I want it to be.  But then I would need to remember to turn it off manually or put `god-mode-all` in `delete-frame-functions`, and that would only work if I deleted the frame while it was on.  Now one can see the way it is right now `god-mode-all` is not the proper function for this task.

To achieve what I wanted, I added an optional argument to `god-mode-all` which controls whether the function toggles god-mode, or strictly activates or deactivates it.  To ensure backwards compatibility, I made sure to make nil as the value for toggling the mode, and as for the positive and negative values for turning it on or off, I followed the convention of `define-minor-mode`.

In the new function, I could have bypassed `mapc` based on the `god-global-mode` variable, but this value is not consistent.  What I mean is that god-mode could have various states for different buffers, and `god-global-mode` was not capable of reliably indicating whether all buffers had god-mode on or off, therefore the only way the new `god-mode-all` function would work properly is by not relying on this value.

As a side note, if all goes well, I will probably create other pull requests with improvements I had made for myself that I think others might also benefit from.