### PR TITLE
Add customization for God mode's minor mode lighter

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -159,7 +159,17 @@ Note that `god-mode-describe-key` is only able to interpret key-bindings that ar
 
 ## Visual indicators for God mode
 
-You can change the cursor style to visually indicate whether God mode is active
+God mode allows you to customize its minor mode lighter by customizing the `god-mode-lighter-string` variable and the `god-mode-lighter` face.
+For example, if you don't want any lighter, you can set the string to nil.
+On the other hand, if you want the lighter to stand out, you can change the face, e.g. by making it inherit from `error`.
+You can do the latter via `M-x customize-face RET god-mode-ligher` or via Lisp:
+
+```emacs-lisp
+(custom-set-faces
+ '(god-mode-lighter ((t (:inherit error)))))
+```
+
+Additionally, you can change the cursor style to visually indicate whether God mode is active
 as follows:
 
 ```emacs-lisp

--- a/.github/README.md
+++ b/.github/README.md
@@ -162,7 +162,7 @@ Note that `god-mode-describe-key` is only able to interpret key-bindings that ar
 God mode allows you to customize its minor mode lighter by customizing the `god-mode-lighter-string` variable and the `god-mode-lighter` face.
 For example, if you don't want any lighter, you can set the string to nil.
 On the other hand, if you want the lighter to stand out, you can change the face, e.g. by making it inherit from `error`.
-You can do the latter via `M-x customize-face RET god-mode-ligher` or via Lisp:
+You can do this using `M-x customize-face RET god-mode-lighter` or as follows:
 
 ```emacs-lisp
 (custom-set-faces

--- a/god-mode.el
+++ b/god-mode.el
@@ -109,6 +109,18 @@ in God mode will be translated to `C-<f5>'."
   :group 'god
   :type 'boolean)
 
+(defcustom god-mode-lighter-string
+  "God"
+  "String displayed on the mode line when God mode is active.
+Set it to nil if you don't want a mode line indicator."
+  :group 'god
+  :type '(choice string (const :tag "None" nil)))
+
+(defface god-mode-lighter
+  '((t))
+  "Face for God mode's lighter."
+  :group 'god)
+
 (defun god-mode-make-f-key (n &optional shift)
   "Get the event for numbered function key N, with shift status SHIFT.
 For example, calling with arguments 5 and t yields the symbol `S-f5'."
@@ -134,7 +146,9 @@ For example, calling with arguments 5 and t yields the symbol `S-f5'."
 (define-minor-mode god-local-mode
   "Minor mode for running commands."
   :init-value nil
-  :lighter " God"
+  :lighter (god-mode-lighter-string
+	    ((" "
+	     (:propertize god-mode-lighter-string face god-mode-lighter))))
   :keymap god-local-mode-map
   (if god-local-mode
       (run-hooks 'god-mode-enabled-hook)

--- a/god-mode.el
+++ b/god-mode.el
@@ -147,8 +147,8 @@ For example, calling with arguments 5 and t yields the symbol `S-f5'."
   "Minor mode for running commands."
   :init-value nil
   :lighter (god-mode-lighter-string
-	    ((" "
-	     (:propertize god-mode-lighter-string face god-mode-lighter))))
+            ((" "
+             (:propertize god-mode-lighter-string face god-mode-lighter))))
   :keymap god-local-mode-map
   (if god-local-mode
       (run-hooks 'god-mode-enabled-hook)


### PR DESCRIPTION
God mode's README makes a few suggestions on how to set up visual indicators but none of them are actually provided by the package itself. Emacs's default visual indicators for modes are their lighters, so I thought it would be good to allow the customization of the face and the string of God mode's lighter, and this is what this patch does:
* adds the `god-mode-lighter-string` variable to allow the change the string "God" or to completely disable the lighter,
* adds the `god-mode-lighter` face to allow the user change the face of the lighter.
If a user had already setup another visual indicator and had removed God mode's lighter by deleting it from `minor-mode-alist`, now it is easier to hide it by just setting `god-mode-lighter-string` to nil.

As an example of the results, you can see below what I do: I use Emacs's default theme and [Nano Theme light](https://github.com/rougier/nano-theme/) and I set `god-mode-lighter` to inherit from `error` and `nano-critical-i` for each theme, respectively. Also, I updated the README and actually added an example of how to set the new face to inherit from `error`, which is the most contrasting default face in Emacs that I could find.

![image](https://user-images.githubusercontent.com/30757952/209983751-64eb999a-7cfd-48eb-a9e8-8c63b23654f0.png)

