### PR TITLE
Allow god-literal-key to be toggled

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -115,10 +115,11 @@ This package defines the following key mappings:
 
 * The literal key (<kbd>SPC</kbd>) is sticky. This means you don't have to enter 
   <kbd>SPC</kbd> repeatedly for key bindings such as <kbd>C-x</kbd> <kbd>r</kbd> <kbd>t</kbd>.
+  Entering the literal key again toggles its state.
   The literal key can be changed through `god-literal-key`. Here are some examples:
   
    * <kbd>x</kbd> <kbd>SPC</kbd> <kbd>r</kbd> <kbd>t</kbd> → <kbd>C-x</kbd> <kbd>r</kbd> <kbd>t</kbd>
-   * <kbd>x</kbd> <kbd>SPC</kbd> <kbd>r</kbd> <kbd>y</kbd> → <kbd>C-x</kbd> <kbd>r</kbd> <kbd>y</kbd>
+   * <kbd>x</kbd> <kbd>SPC</kbd> <kbd>r</kbd> <kbd>SPC</kbd> <kbd>g</kbd> <kbd>w</kbd> → <kbd>C-x</kbd> <kbd>r</kbd> <kbd>M-w</kbd>
 
 * <kbd>g</kbd> is used to indicate the meta modifier (<kbd>M-</kbd>). This means
   that there is no way to enter <kbd>C-g</kbd> in God mode, and you must

--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -54,6 +54,12 @@ Feature: C- commands
     When I send the key sequence "c SPC b e g"
     Then the cursor should be at point "1"
 
+  Scenario: toggle god-literal-key
+    Given I bind "C-c k M-l" to "beginning-of-buffer"
+    And I go to end of buffer
+    When I send the key sequence "c SPC k SPC g l"
+    Then the cursor should be at point "1"
+
   Scenario: execute commands with C-arrow
     Given I bind "C-x C-<left>" to "backward-word"
     And I go to line "1"

--- a/god-mode.el
+++ b/god-mode.el
@@ -318,9 +318,9 @@ Appends to key sequence KEY-STRING-SO-FAR."
     (unless god-literal-sequence
       (let ((modifier-lookup (and (stringp key) (assoc key god-mode-alist))))
         (if modifier-lookup
-	    (setq modifier (cdr modifier-lookup)
+            (setq modifier (cdr modifier-lookup)
                   key (funcall next-key))
-	  (setq modifier (cdr (assoc nil god-mode-alist))))))
+          (setq modifier (cdr (assoc nil god-mode-alist))))))
     (if (and key-string-so-far (string= key (format "%c" help-char)))
         (god-mode-help-char-dispatch key key-string-so-far)
       (when (and (= (length key) 1)

--- a/god-mode.el
+++ b/god-mode.el
@@ -309,7 +309,7 @@ from the command loop."
 Consumes more keys if appropriate.
 Appends to key sequence KEY-STRING-SO-FAR."
   (let ((modifier "")
-	(next-key (lambda () (god-mode-sanitized-key-string (read-event key-string-so-far)))))
+        (next-key (lambda () (god-mode-sanitized-key-string (read-event key-string-so-far)))))
     (message key-string-so-far)
     (when key-string-so-far ; Don't check for `god-literal-key' with the first key.
       (while (string= key god-literal-key)


### PR DESCRIPTION
The changes allow god-literal-key to be toggled.  This is necessary when modified keys follow literal keys in a key sequence.  E.g. `C-x r M-y` for `copy-rectangle-as-kill` can now be entered as `x SPC r SPC g y`.

Should the version be bumped to `2.19.0`?

Shortcomings: `C-SPC` can still not be entered within a key sequence.  E.g. `C-x r C-SPC` for `point-to-register` can't currently be entered in `god-mode`.

Beside the Ecukes test, the code was verified with

```elisp
(defun god-mode-translate (key-string)
  (let* ((key-list (cl-coerce key-string 'list))
         (pop-key-list (lambda (&rest _) (pop key-list)))
         god-literal-sequence string-so-far)
    (advice-add 'read-event :override pop-key-list)
    (unwind-protect (cl-loop for key = (read-event) unless key return string-so-far
                             do (let ((sanitized-key (god-mode-sanitized-key-string key)))
                                  (setq string-so-far (god-key-string-after-consuming-key sanitized-key string-so-far))))
      (advice-remove 'read-event pop-key-list))))

(let ((god-mode-tests '("x x x" "C-x x C-x"
                        "x xx" "C-x x x"
                        "xxx" "C-x C-x C-x"
                        "x xx xx x" "C-x x x C-x C-x x"
                        "x x gx" "C-x x M-x"
                        "x xgx" "C-x x g x"
                        "x  x" "C-x C-x"
                        "x   x" "C-x x")))
  (cl-loop for (input output) on god-mode-tests by #'cddr
           for translation = (god-mode-translate input)
           for success = (string= translation output)
           count (not success)
           unless success do (message "%S => %S =/= %S" input translation output)))
```