### PR TITLE
Added evil-god-toggle to list of options for evil

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -360,6 +360,20 @@ customizations that enable them to be used together smoothly.
   default Emacs keybindings through God mode. However, a disadvantage of
   `evil-god-state` is that Evil's state-specific keybindings will not be
   available in God mode.
+ 
+* [`evil-god-toggle`] is an expanded version of `evil-god-state` with features
+  like persistence of visual selections to corresponding active regions,
+  global `god-mode` scope, and a `god-off` which is like `emacs-state` but
+  more easy to toggle in and out of.  The ability to use a persistent
+  `god-state` is also better documented.
+
+ 
+ 
+ 
+ 
+ 
+ 
+ 
 
 [useful-key-bindings]: #useful-key-bindings
 [key-mapping]: #key-mapping
@@ -372,4 +386,5 @@ customizations that enable them to be used together smoothly.
 [gh-actions-badge]: https://github.com/emacsorphanage/god-mode/actions/workflows/test.yml/badge.svg?branch=master
 [evil]: https://github.com/emacs-evil/evil
 [evil-god-state]: https://github.com/gridaphobe/evil-god-state
+[evil-god-toggle]: https://github.com/jam1015/evil-god-toggle
 [window-hooks]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Window-Hooks.html


### PR DESCRIPTION
`evil-god-toggle` (https://github.com/jam1015/evil-god-toggle) is a package I wrote that expands on evil-god-state. Added it to the list of ways to use god-mode with evil. Offers features of evil-god state plus better transferring of visual mode to active regions, toggling across all buffers, god-off state which is like emacs-state but easier to switch in and out of.   

It was accepted to MELPA today.  Hope it will be on MELPA-stable soon. 

There are no changes to the package code, just added a bullet to the README.