### PR TITLE
fixed typo in links

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -361,11 +361,13 @@ customizations that enable them to be used together smoothly.
   `evil-god-state` is that Evil's state-specific keybindings will not be
   available in God mode.
  
-* [`evil-god-toggle`] is an expanded version of `evil-god-state` with features
-  like persistence of visual selections to corresponding active regions,
-  global `god-mode` scope, and a `god-off` which is like `emacs-state` but
-  more easy to toggle in and out of.  The ability to use a persistent
-  `god-state` is also better documented.
+* [`evil-god-toggle`][evil-god-toggle] is an expanded version of
+  `evil-god-state` with features like persistence of visual selections
+  to corresponding active regions, global `god-mode` scope, and a
+  `god-off` which is like `emacs-state` but more easy to toggle in and
+  out of.  The ability to use a persistent `god-state` is also better
+  documented.
+ 
 
  
  


### PR DESCRIPTION
the previous PR commit: https://github.com/emacsorphanage/god-mode/commit/4f6d3cd479d44d3d34cd541ae97c604b3f13e198  

had a typo   .   Didn't format a markdown link correctly.

This doesn't change code just updates README.md 
