### PR TITLE
fallback for commands: if no C-a C-b then try C-a b

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -338,17 +338,41 @@ Appends to key sequence KEY-STRING-SO-FAR."
         (concat modifier key)))))
 
 (defun god-mode-lookup-command (key-string)
-  "Execute extended keymaps in KEY-STRING, or call it if it is a command."
+  "Look up and return the command for KEY-STRING.
+Tries fallback for the last key by removing Control modifier. If no command is found,
+returns a keymap to allow further key input, or nil if completely unbound."
   (when key-string
     (let* ((key-vector (read-kbd-macro key-string t))
            (binding (key-binding key-vector)))
-      (cond ((commandp binding)
-             (setq last-command-event (aref key-vector (- (length key-vector) 1)))
-             binding)
-            ((keymapp binding)
-             (god-mode-lookup-key-sequence nil key-string))
-            (:else
-             (error "God: Unknown key binding for `%s`" key-string))))))
+      (cond
+       ;; Case 1: found an actual command
+       ((commandp binding)
+        (setq last-command-event (aref key-vector (1- (length key-vector))))
+        binding)
+
+       ;; Case 2: it's a keymap (partial key sequence)
+       ((keymapp binding)
+        (god-mode-lookup-key-sequence nil key-string))
+
+       ;; Case 3: try fallback by removing C- from the last key
+       ((string-match "\\(.*\\) C-\\(.\\)$" key-string)
+        (let* ((prefix (match-string 1 key-string))
+               (last (match-string 2 key-string))
+               (fallback-key (string-trim (format "%s %s" prefix last)))
+               (fallback-vector (read-kbd-macro fallback-key t))
+               (fallback-binding (key-binding fallback-vector)))
+          (cond
+           ((commandp fallback-binding)
+            (message "Using fallback command: %s" fallback-key)
+            (setq last-command-event (aref fallback-vector (1- (length fallback-vector))))
+            fallback-binding)
+
+           ((keymapp fallback-binding)
+            (message "Using fallback keymap: %s" fallback-key)
+            (god-mode-lookup-key-sequence nil fallback-key))
+
+           ;; Not a command nor a map — wait for more input, don't fail
+           )))))))
 
 ;;;###autoload
 (defun god-mode-maybe-activate (&optional status)


### PR DESCRIPTION
**What does it do?**: right now when you type a command, let's say "a s", then god mode tries "C-a C-s" and that's it. This commit adds a fallback so if there is no binding for "C-a C-s" god mode will try for "C-a s" first and if there is no such a binding it will wait for next input.

**Why I want it?**: I have quite a lot of custom bindings like "C-a s" to choose persp or "C-a b i" to open ibuffer for a persp etc. Instead of remapping all my bindings (tedious) or type "b a SPC s" (b enters god mode on my setup), I though it would be cool to add fallback functionality as it is done in meow. Realization of the idea may have some flaws, I don't know how it works in meow exactly but for now it works for me.

**Why I made a pr instead of just rewriting function in my init file?**: I've already done that and I though that some other god-mode users may also find this functionality convenient.