### PR TITLE
fixed C-x 8 not working

### DIFF
--- a/god-mode.el
+++ b/god-mode.el
@@ -222,6 +222,7 @@ is a negative number."
   (let* ((initial-key (aref (this-command-keys-vector)
                             (- (length (this-command-keys-vector)) 1)))
          (binding (god-mode-lookup-key-sequence initial-key)))
+    (setq god-literal-sequence nil)
     (when binding
       ;; For now, set the shift-translation status only for alphabetic keys.
       (when (god-mode-upper-p initial-key)
@@ -231,10 +232,15 @@ is a negative number."
       ;; `real-this-command' is used by emacs to populate
       ;; `last-repeatable-command', which is used by `repeat'.
       (setq real-this-command binding)
-      (setq god-literal-sequence nil)
       (if (commandp binding t)
           (call-interactively binding)
-        (execute-kbd-macro binding)))))
+        ;; Pause god-mode while executing keyboard macros: god-local-mode-map
+        ;; binds chars 32–255 to god-mode-self-insert, which would intercept
+        ;; the macro's character events before they reach self-insert-command.
+        (god-local-mode-pause)
+        (unwind-protect
+            (execute-kbd-macro binding)
+          (god-local-mode-resume))))))
 
 (defun god-mode-upper-p (key)
   "Check if KEY is an upper case character not present in `god-mode-alist'."
@@ -377,7 +383,19 @@ returns a keymap to allow further key input, or nil if completely unbound."
             (god-mode-lookup-key-sequence nil fallback-key))
 
            ;; Not a command nor a map — wait for more input, don't fail
-           )))))))
+           )))
+
+       ;; Case 4: consult key-translation-map.  iso-transl registers C-x 8
+       ;; sequences there rather than in the global keymap, so key-binding
+       ;; alone cannot find them.
+       (t
+        (let ((translation (lookup-key key-translation-map key-vector)))
+          (cond
+           ((keymapp translation)
+            (god-mode-lookup-key-sequence nil key-string))
+           (translation
+            (setq last-command-event (aref key-vector (1- (length key-vector))))
+            translation))))))))
 
 ;;;###autoload
 (defun god-mode-maybe-activate (&optional status)


### PR DESCRIPTION


# Done with AI

This PR was written with the help of an AI tool, I couldn't have done it on my own.  If you don't want AI written code in god-mode that is fine, I can just keep these changes in my own fork.

# Fix: `C-x 8` sequences silently do nothing in god-mode

## Symptoms

In `god-local-mode`, key sequences that route through `C-x 8` (the
`iso-transl` compose prefix) produce no output and no error.  For example:

| God-mode sequence | Expected | Actual |
|---|---|---|
| `x SPC 8 u` | inserts `μ` | nothing |
| `x SPC 8 P` | inserts `¶` | nothing |
| `x SPC 8 o` | inserts `°` | nothing |

The same sequences typed outside god-mode (`C-x 8 u` etc.) work correctly.
`x SPC 8 RET` also works in god-mode because `C-x 8 RET` is bound to the
named command `insert-char`, not a keyboard macro.

---

## Root causes

### 1. `god-mode-lookup-command` does not search `key-translation-map`

`iso-transl` registers its `C-x 8` character translations in
`key-translation-map`, not in the global keymap.  Emacs's `key-binding`
function does not search `key-translation-map`, so
`(key-binding (kbd "C-x 8 u"))` returns `nil`.

`god-mode-lookup-command` called `key-binding` and fell through all three
existing cases without finding anything, returning `nil`.  Back in
`god-mode-self-insert` the `(when binding ...)` guard skipped execution
entirely — hence the silent no-op.

### 2. `execute-kbd-macro` re-routes through `god-local-mode-map`

Once the lookup is fixed and a translation vector such as `[?μ]` is
returned, a second problem appears: `(commandp [?μ] t)` is `nil` (keyboard
macros are excluded from the `for-call-interactively` check), so
`god-mode-self-insert` falls to the `else` branch and calls
`(execute-kbd-macro [?μ])`.

`god-local-mode-map` binds all characters in the range 32–255 to
`god-mode-self-insert`.  `μ` (U+03BC = 956, outside that range) would
actually pass through, but other common translations such as `°` (U+00B0 =
176) fall inside the range and would be silently consumed.  The correct
approach is to pause god-mode for the synchronous duration of any keyboard
macro so that macro characters reach `self-insert-command` unconditionally.

### 3. `god-literal-sequence` not reset on lookup failure (minor)

`(setq god-literal-sequence nil)` was inside `(when binding ...)`, so it was
skipped whenever the lookup returned `nil`.  This could leave
`god-literal-sequence` stuck in the toggled state after an unbound sequence,
requiring an extra `SPC` to recover.

---

## Changes

All changes are in `god-mode.el`.

### `god-mode-lookup-command` — new Case 4

After the existing three cases fail, consult `key-translation-map`:

```elisp
;; Case 4: consult key-translation-map.  iso-transl registers C-x 8
;; sequences there rather than in the global keymap, so key-binding
;; alone cannot find them.
(t
 (let ((translation (lookup-key key-translation-map key-vector)))
   (cond
    ((keymapp translation)
     (god-mode-lookup-key-sequence nil key-string))
    (translation
     (setq last-command-event (aref key-vector (1- (length key-vector))))
     translation))))
```

If the translation is itself a keymap (e.g. `C-x 8 1`, which is a prefix
for `¼`, `†`, etc.), the existing recursive key-reading path handles it
naturally.

### `god-mode-self-insert` — pause god-mode around `execute-kbd-macro`

```elisp
;; Before
(execute-kbd-macro binding)

;; After
(god-local-mode-pause)
(unwind-protect
    (execute-kbd-macro binding)
  (god-local-mode-resume))
```

`god-local-mode-pause` and `god-local-mode-resume` are the existing
suspend/restore helpers.  `execute-kbd-macro` on a character vector is
synchronous, so god-mode is re-enabled only after the characters have been
processed by `self-insert-command`.

### `god-mode-self-insert` — always reset `god-literal-sequence`

Moved `(setq god-literal-sequence nil)` from inside `(when binding ...)` to
before it, so the flag is cleared regardless of whether a binding was found.

---

## Tests

### Fix-specific tests (`test-god-mode-fix.el`)

Verifies the two-part fix in isolation.  Run with:

```
emacs -Q --batch -L elpaca/sources/god-mode \
      --eval "(require 'god-mode)" \
      --load test-god-mode-fix.el
```

| Test | What it checks |
|---|---|
| `key-translation-map` has `C-x 8 u/P/o` | iso-transl baseline |
| `god-mode-lookup-command C-x 8 u` → `[956]` | Case 4 fires correctly |
| `god-mode-lookup-command C-x 8 P/o` → vector | Case 4 for other chars |
| `god-mode-lookup-command C-x 8 RET` → `insert-char` | Named command path unchanged |
| `commandp [956]` vs `commandp [956] t` | Explains why else-branch runs |
| `execute-kbd-macro` called with god-mode paused | Pause/resume fix verified |
| `god-literal-sequence` reset with nil binding | Secondary fix verified |
| `god-local-mode-pause/resume` round-trip | Mechanism verified |

Result: **12/12 pass**

### Regression tests (`test-god-mode-regression.el`)

Verifies that existing god-mode behaviour is unaffected.  Run with:

```
emacs -Q --batch -L elpaca/sources/god-mode \
      --eval "(require 'god-mode)" \
      --load test-god-mode-regression.el
```

| Category | Tests |
|---|---|
| Key lookup: common sequences | `C-x C-s`, `C-x C-f`, `M-x`, `C-n`, `M-f`, `C-x C-b` |
| Fallback (Case 3): strip `C-` | `C-c C-a` → `C-c a` |
| iso-transl fix | `C-x 8 u/P/o` return vectors; `C-x 8 1` correctly identified as sub-keymap |
| No shadowing by Case 4 | Regular bindings (`C-x C-s`) still take priority |
| Pause/resume mechanism | Disable, flag set/cleared, no-op when not paused |
| Predicates | `fundamental-mode` not exempt; `dired-mode` exempt; `god-passes-predicates-p` |
| `god-mode-upper-p` | Uppercase detection and alist exclusion |

Result: **25/25 pass**

### Upstream Ecukes integration tests

The upstream test suite (`features/*.feature`) uses
[Ecukes](https://github.com/ecukes/ecukes) and requires an interactive
display.  Ecukes is not available in this environment.  The scenarios covered
include: C-commands, digit arguments, prefix arguments, literal sequences,
named keyboard macros, `god-literal-key` toggling, regions, repeat, and
predicate-based disable.

The batch regression suite above covers the lookup and dispatch logic that
underlies all of those scenarios.  The interactive smoke test below confirms
end-to-end behaviour.

### Interactive smoke test

```
emacs --with-profile god
```

In a writable buffer with `god-local-mode` active:

- `x SPC 8 u` → inserts `μ`
- `x SPC 8 P` → inserts `¶`
- `x SPC 8 o` → inserts `°`
- `x SPC 8 RET` → opens `insert-char` prompt (unchanged)
- `x s` → saves buffer via `C-x C-s` (normal god-mode sequence unchanged)
- `f` → `C-f` forward char (unchanged)
